### PR TITLE
完善uni-list组件中ListItem Props的参数说明

### DIFF
--- a/uni_modules/uni-list/readme.md
+++ b/uni_modules/uni-list/readme.md
@@ -212,8 +212,11 @@ to				|String		|-			|	新页面跳转地址，如填写此属性，click 会返�
 clickable		|Boolean	|false		|	是否开启点击反馈
 showSwitch	    |Boolean	|false		|	是否显示Switch																			
 switchChecked	|Boolean	|false		|	Switch是否被选中																			
-showExtraIcon   |Boolean	|false		|	左侧是否显示扩展图标																		
+showExtraIcon   |Boolean	|false		|	左侧是否显示扩展图标
 extraIcon		|Object		|-			|	扩展图标参数，格式为 ``{color: '#4cd964',size: '22',type: 'spinner'}``，参考 [uni-icons](https://ext.dcloud.net.cn/plugin?id=28)	
+border | Boolean | true | 是否显示列表项边框
+customStyle | Object | ``{padding: '',backgroundColor: '#FFFFFF'}`` | 自定义列表项内边距和背景颜色
+keepScrollPosition | Boolean | false | 插入单元格后是否保持最后一个滑动位置
 direction		| String	|row		|	排版方向，可选值，row:水平排列;  column:垂直排列; 3个插槽是水平排还是垂直排，也受此属性控制
 
 


### PR DESCRIPTION
最近开发过程中使用到uni-list组件，想隐藏列表项的边框，发现仅有List Props中可以配置，配置后发现只关闭了父组件的边框，列表单项没有隐藏，经尝试后，列表项目也可以配置border为false，但是文档却没有说明，查看源码发现还有其他几个参数也未说明，于是一并补齐。